### PR TITLE
chore: ruff moved to astral-sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,14 +21,14 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
 
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.264"
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: "v0.0.275"
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.2.0"
+    rev: "v1.4.1"
     hooks:
       - id: mypy
         files: ^src/hypernewsviewer/model/
@@ -55,7 +55,7 @@ repos:
           - rich
 
   - repo: https://github.com/codespell-project/codespell
-    rev: "v2.2.4"
+    rev: "v2.2.5"
     hooks:
       - id: codespell
         args: ["-Lslac"]
@@ -77,19 +77,19 @@ repos:
         additional_dependencies: [js-beautify]
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "0.11.1"
+    rev: "0.12.1"
     hooks:
       - id: pyproject-fmt
 
   - repo: https://github.com/henryiii/check-sdist
-    rev: v0.1.0
+    rev: v0.1.2
     hooks:
       - id: check-sdist
         args: [--inject-junk]
         additional_dependencies: [hatchling]
 
   - repo: https://github.com/pdm-project/pdm
-    rev: 2.5.3
+    rev: 2.8.0a2
     hooks:
       - id: pdm-export
         args: [-o, requirements.txt, -Gdeploy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,45 @@ optional-dependencies.test = [
 ]
 scripts.hyper-model = "hypernewsviewer.model.__main__:main"
 
+[tool.ruff]
+select = [
+  "E", "F", "W", # flake8
+  "B",           # flake8-bugbear
+  "I",           # isort
+  "ARG",         # flake8-unused-arguments
+  "C4",          # flake8-comprehensions
+  "EM",          # flake8-errmsg
+  "ICN",         # flake8-import-conventions
+  "ISC",         # flake8-implicit-str-concat
+  "G",           # flake8-logging-format
+  "PGH",         # pygrep-hooks
+  "PIE",         # flake8-pie
+  "PL",          # pylint
+  "PT",          # flake8-pytest-style
+  "PTH",         # flake8-use-pathlib
+  "RET",         # flake8-return
+  "RUF",         # Ruff-specific
+  "SIM",         # flake8-simplify
+  "T20",         # flake8-print
+  "UP",          # pyupgrade
+  "YTT",         # flake8-2020
+  "EXE",         # flake8-executable
+  "NPY",         # NumPy specific rules
+  "PD",          # pandas-vet
+]
+extend-ignore = [
+  "PLR",    # Design related pylint codes
+  "E501",   # Line too long
+]
+typing-modules = ["hypernewsviewer._compat.typing"]
+src = ["src"]
+unfixable = [
+  "T20",  # Removes print statements
+  "F841", # Removes unused variables
+]
+flake8-unused-arguments.ignore-variadic-names = true
+per-file-ignores."tests/**" = ["T20"]
+
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
@@ -93,43 +132,3 @@ messages_control.disable = [
   "no-member",
   "redefined-builtin",
 ]
-
-[tool.ruff]
-select = [
-  "E", "F", "W", # flake8
-  "B",           # flake8-bugbear
-  "I",           # isort
-  "ARG",         # flake8-unused-arguments
-  "C4",          # flake8-comprehensions
-  "EM",          # flake8-errmsg
-  "ICN",         # flake8-import-conventions
-  "ISC",         # flake8-implicit-str-concat
-  "G",           # flake8-logging-format
-  "PGH",         # pygrep-hooks
-  "PIE",         # flake8-pie
-  "PL",          # pylint
-  "PT",          # flake8-pytest-style
-  "PTH",         # flake8-use-pathlib
-  "RET",         # flake8-return
-  "RUF",         # Ruff-specific
-  "SIM",         # flake8-simplify
-  "T20",         # flake8-print
-  "UP",          # pyupgrade
-  "YTT",         # flake8-2020
-  "EXE",         # flake8-executable
-  "NPY",         # NumPy specific rules
-  "PD",          # pandas-vet
-]
-extend-ignore = [
-  "PLR",    # Design related pylint codes
-  "E501",   # Line too long
-]
-target-version = "py38"
-typing-modules = ["hypernewsviewer._compat.typing"]
-src = ["src"]
-unfixable = [
-  "T20",  # Removes print statements
-  "F841", # Removes unused variables
-]
-flake8-unused-arguments.ignore-variadic-names = true
-per-file-ignores."tests/**" = ["T20"]


### PR DESCRIPTION
See scientific-python/cookie#200. Also See scientific-python/cookie#201, Ruff now infers the target version for modern packages.
