### PR TITLE
chore: cleaner logs

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -1,6 +1,20 @@
 from __future__ import annotations
 
+import logging
+
 from hypernewsviewer.app import app as application
+
+
+class HealthCheckFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        msg = record.getMessage()
+        return not ("kube-probe" in msg and '"GET / HTTP/1.1" 200' in msg)
+
+
+# Remove health check from application server logs
+logging.getLogger("uvicorn.access").addFilter(HealthCheckFilter())
+
+logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
     application.run()

--- a/wsgi.py
+++ b/wsgi.py
@@ -8,7 +8,7 @@ from hypernewsviewer.app import app as application
 class HealthCheckFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
         msg = record.getMessage()
-        return not ("kube-probe" in msg and '"GET / HTTP/1.1" 200' in msg)
+        return "kube-probe" not in msg or '"GET / HTTP/1.1" 200' not in msg
 
 
 # Remove health check from application server logs


### PR DESCRIPTION
Removing these lines:

```
10.76.115.1 - - [18/Sep/2023:14:13:00 +0000] "GET / HTTP/1.1" 200 2183 "-" "kube-probe/1.25"
```
